### PR TITLE
removed specific zone from WCL request. NH logs working

### DIFF
--- a/server.js
+++ b/server.js
@@ -24,7 +24,7 @@ app.get('/:region/:server/:characterName', (req, res) => {
   const wclKey = process.env.WCL_KEY;
   const cleanCharacterName = htmlEncode(req.params.characterName);
   const blizzRequestUrl = `https://${region}.api.battle.net/wow/character/${serverDash}/${cleanCharacterName}?fields=progression,items&locale=en_US&apikey=${blizzKey}`;
-  const wclRequestUrl = `https://www.warcraftlogs.com:443/v1/rankings/character/${cleanCharacterName}/${serverDash}/${region}?zone=10-&api_key=${wclKey}`;
+  const wclRequestUrl = `https://www.warcraftlogs.com:443/v1/rankings/character/${cleanCharacterName}/${serverDash}/${region}?api_key=${wclKey}`;
 
   console.log('server', serverDash);
 


### PR DESCRIPTION
Updating logs so that Nighthold logs will be pulled in and shown. I had a workaround for Halls of Valor and Emerald Nightmare being considered the same tier while only making one WCL request. Removed the band-aid so that it pulls the latest tier's worth of logs.